### PR TITLE
Update results limit from 250 to 500

### DIFF
--- a/server/handlers/v1/titleSearch/index.js
+++ b/server/handlers/v1/titleSearch/index.js
@@ -21,7 +21,7 @@ const buildAdvanced = (search, alpha) => {
       )
       GROUP BY t.title, t.titleId, t.publisher, t.yearsPublished
       ORDER BY issueCount DESC, t.title ASC
-      LIMIT 250`;
+      LIMIT 500`;
 
   const params = [search];
   return { query, params };
@@ -45,7 +45,7 @@ const buildSearch = (search, alpha) => {
       )
       GROUP BY t.title, t.titleId, t.publisher, t.yearsPublished
       ORDER BY issueCount DESC, t.title ASC
-      LIMIT 250`;
+      LIMIT 500`;
 
   const params = [search, alpha];
   return { query, params };


### PR DESCRIPTION
Increase the results limit of a title from 250 to 500 so that more obscure title results can be returned